### PR TITLE
feat(api/mastodon): 引用・返信を実装

### DIFF
--- a/api/mastodon/authenticate_test.go
+++ b/api/mastodon/authenticate_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"testing"
+	"time"
 
 	"github.com/arrow2nd/nekomata/api/shared"
 	"github.com/stretchr/testify/assert"
@@ -40,6 +41,8 @@ func TestRecieveCode(t *testing.T) {
 	t.Run("受け取れるか", func(t *testing.T) {
 		result := make(chan *result, 1)
 		go run(result)
+
+		time.Sleep(time.Second)
 
 		wantCode := "CODE"
 		res, err := postCallback(wantCode)

--- a/api/misskey/note.go
+++ b/api/misskey/note.go
@@ -6,6 +6,14 @@ func (m *Misskey) CreatePost(opts *shared.CreatePostOpts) (*shared.Post, error) 
 	return nil, nil
 }
 
+func (m Misskey) QuotePost(id string, opts *shared.CreatePostOpts) (*shared.Post, error) {
+	return nil, nil
+}
+
+func (m Misskey) ReplyPost(id string, opts *shared.CreatePostOpts) (*shared.Post, error) {
+	return nil, nil
+}
+
 func (m *Misskey) DeletePost(id string) (*shared.Post, error) {
 	return nil, nil
 }

--- a/api/shared/client.go
+++ b/api/shared/client.go
@@ -9,6 +9,10 @@ type Client interface {
 	GetAnnouncements() ([]*Announcement, error)
 	// CreatePost : 投稿を作成
 	CreatePost(*CreatePostOpts) (*Post, error)
+	// QuotePost : 投稿を引用
+	QuotePost(string, *CreatePostOpts) (*Post, error)
+	// ReplyPost : 投稿に返信
+	ReplyPost(string, *CreatePostOpts) (*Post, error)
 	// DeletePost : 投稿を削除
 	DeletePost(string) (*Post, error)
 }


### PR DESCRIPTION
引用は Mastodon に実装されていない機能なので、常にエラーを返すようにした
(今後も実装しないつもり)
