### PR TITLE
feat(api/mastodon): fav・unfav を実装

### DIFF
--- a/api/mastodon/announcements.go
+++ b/api/mastodon/announcements.go
@@ -20,7 +20,7 @@ func (m *Mastodon) GetAnnouncements() ([]*shared.Announcement, error) {
 	q.Add("with_dismissed", "false")
 
 	res := []*announcement{}
-	url := announcementsEndpoint.URL(m.opts.Server)
+	url := announcementsEndpoint.URL(m.opts.Server, nil)
 	if err := m.request("GET", url, q, true, &res); err != nil {
 		return nil, err
 	}

--- a/api/mastodon/authenticate.go
+++ b/api/mastodon/authenticate.go
@@ -51,6 +51,7 @@ func (m *Mastodon) recieveCode() (string, error) {
 
 func (m *Mastodon) recieveToken(code string) (*shared.User, error) {
 	q := url.Values{}
+
 	q.Add("grant_type", "authorization_code")
 	q.Add("code", code)
 	q.Add("client_id", m.opts.ID)
@@ -58,8 +59,8 @@ func (m *Mastodon) recieveToken(code string) (*shared.User, error) {
 	q.Add("redirect_uri", shared.AuthCallbackURL)
 
 	res := &authenticateResponse{}
-	url := oauthTokenEndpoint.URL(m.opts.Server, nil)
-	if err := m.request("POST", url, q, false, res); err != nil {
+	endpoint := oauthTokenEndpoint.URL(m.opts.Server, nil)
+	if err := m.request("POST", endpoint, q, false, res); err != nil {
 		return nil, err
 	}
 

--- a/api/mastodon/authenticate.go
+++ b/api/mastodon/authenticate.go
@@ -32,13 +32,15 @@ func (m *Mastodon) Authenticate(w io.Writer) (*shared.User, error) {
 }
 
 func (m *Mastodon) createAuthorizeURL(permissions []string) string {
-	q := &url.Values{}
+	q := url.Values{}
+
 	q.Add("response_type", "code")
 	q.Add("client_id", m.opts.ID)
 	q.Add("redirect_uri", shared.AuthCallbackURL)
 	q.Add("scope", strings.Join(permissions, " "))
 
-	return oauthAuthorizeEndpoint.URL(m.opts.Server) + "?" + q.Encode()
+	endpoint := oauthAuthorizeEndpoint.URL(m.opts.Server, nil)
+	return endpoint + "?" + q.Encode()
 }
 
 func (m *Mastodon) recieveCode() (string, error) {
@@ -56,12 +58,10 @@ func (m *Mastodon) recieveToken(code string) (*shared.User, error) {
 	q.Add("redirect_uri", shared.AuthCallbackURL)
 
 	res := &authenticateResponse{}
-	url := oauthTokenEndpoint.URL(m.opts.Server)
+	url := oauthTokenEndpoint.URL(m.opts.Server, nil)
 	if err := m.request("POST", url, q, false, res); err != nil {
 		return nil, err
 	}
 
-	return &shared.User{
-		Token: res.AccessToken,
-	}, nil
+	return &shared.User{Token: res.AccessToken}, nil
 }

--- a/api/mastodon/authenticate_test.go
+++ b/api/mastodon/authenticate_test.go
@@ -43,7 +43,7 @@ func TestRecieveCode(t *testing.T) {
 		result := make(chan *result, 1)
 		go run(result)
 
-		time.Sleep(time.Second)
+		time.Sleep(time.Second * 1)
 
 		wantCode := "CODE"
 		res, err := postCallback(wantCode)

--- a/api/mastodon/authenticate_test.go
+++ b/api/mastodon/authenticate_test.go
@@ -16,7 +16,8 @@ func TestCreateAuthorizeURL(t *testing.T) {
 	m := &Mastodon{opts: &shared.ClientOpts{Server: "https://example.com", ID: "hoge"}}
 	u := m.createAuthorizeURL([]string{"aaaa", "bbbb"})
 
-	want := oauthAuthorizeEndpoint.URL(m.opts.Server) + "?client_id=hoge&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Fcallback&response_type=code&scope=aaaa+bbbb"
+	wantURL := oauthAuthorizeEndpoint.URL(m.opts.Server, nil)
+	want := wantURL + "?client_id=hoge&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Fcallback&response_type=code&scope=aaaa+bbbb"
 	assert.Equal(t, want, u)
 }
 

--- a/api/mastodon/authenticate_test.go
+++ b/api/mastodon/authenticate_test.go
@@ -14,8 +14,8 @@ func TestCreateAuthorizeURL(t *testing.T) {
 	m := &Mastodon{opts: &shared.ClientOpts{Server: "https://example.com", ID: "hoge"}}
 	u := m.createAuthorizeURL([]string{"aaaa", "bbbb"})
 
-	wantURL := oauthAuthorizeEndpoint.URL(m.opts.Server, nil)
-	want := wantURL + "?client_id=hoge&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Fcallback&response_type=code&scope=aaaa+bbbb"
+	endpoint := oauthAuthorizeEndpoint.URL(m.opts.Server, nil)
+	want := endpoint + "?client_id=hoge&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Fcallback&response_type=code&scope=aaaa+bbbb"
 	assert.Equal(t, want, u)
 }
 

--- a/api/mastodon/authenticate_test.go
+++ b/api/mastodon/authenticate_test.go
@@ -4,9 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"net/url"
 	"testing"
-	"time"
 
 	"github.com/arrow2nd/nekomata/api/shared"
 	"github.com/stretchr/testify/assert"
@@ -34,16 +32,15 @@ func TestRecieveCode(t *testing.T) {
 	}
 
 	postCallback := func(code string) (*http.Response, error) {
-		q := url.Values{}
-		q.Add("code", code)
-		return http.Post(shared.AuthCallbackURL+"?"+q.Encode(), "", nil)
+		req, _ := http.NewRequest("POST", shared.AuthCallbackURL, nil)
+		req.URL.RawQuery = "code=" + code
+		c := http.DefaultClient
+		return c.Do(req)
 	}
 
 	t.Run("受け取れるか", func(t *testing.T) {
 		result := make(chan *result, 1)
 		go run(result)
-
-		time.Sleep(time.Second * 1)
 
 		wantCode := "CODE"
 		res, err := postCallback(wantCode)

--- a/api/mastodon/client.go
+++ b/api/mastodon/client.go
@@ -29,7 +29,9 @@ func (m *Mastodon) request(method, url string, q url.Values, auth bool, out inte
 		req.Header.Set("Authorization", "Bearer "+m.opts.UserToken)
 	}
 
-	req.URL.RawQuery = q.Encode()
+	if q != nil {
+		req.URL.RawQuery = q.Encode()
+	}
 
 	client := http.DefaultClient
 	res, err := client.Do(req)

--- a/api/mastodon/client_test.go
+++ b/api/mastodon/client_test.go
@@ -44,7 +44,7 @@ func TestRequest(t *testing.T) {
 
 	t.Run("リクエストに失敗", func(t *testing.T) {
 		m := &Mastodon{opts: &shared.ClientOpts{Server: "http://localhost:9999"}}
-		u := announcementsEndpoint.URL(m.opts.Server)
+		u := announcementsEndpoint.URL(m.opts.Server, nil)
 		err := m.request("POST", u, nil, false, nil)
 		e := &shared.RequestError{}
 		assert.ErrorAs(t, err, &e)
@@ -52,7 +52,7 @@ func TestRequest(t *testing.T) {
 
 	t.Run("アクセス失敗", func(t *testing.T) {
 		m := &Mastodon{opts: &shared.ClientOpts{Server: ts.URL}}
-		u := announcementsEndpoint.URL(m.opts.Server)
+		u := announcementsEndpoint.URL(m.opts.Server, nil)
 		err := m.request("POST", u, nil, false, nil)
 		e := &shared.HTTPError{}
 		assert.ErrorAs(t, err, &e)
@@ -60,7 +60,7 @@ func TestRequest(t *testing.T) {
 
 	t.Run("JSONデコードエラー", func(t *testing.T) {
 		m := &Mastodon{opts: &shared.ClientOpts{Server: ts.URL}}
-		u := announcementsEndpoint.URL(m.opts.Server)
+		u := announcementsEndpoint.URL(m.opts.Server, nil)
 		err := m.request("POST", u, nil, false, nil)
 		e := &shared.DecodeError{}
 		assert.ErrorAs(t, err, &e)
@@ -68,7 +68,7 @@ func TestRequest(t *testing.T) {
 
 	t.Run("エラーレスポンス", func(t *testing.T) {
 		m := &Mastodon{opts: &shared.ClientOpts{Server: ts.URL}}
-		u := announcementsEndpoint.URL(m.opts.Server)
+		u := announcementsEndpoint.URL(m.opts.Server, nil)
 		err := m.request("POST", u, nil, false, nil)
 		e := &errorResponse{}
 		assert.ErrorAs(t, err, &e)
@@ -81,7 +81,7 @@ func TestRequest(t *testing.T) {
 	t.Run("認証情報がヘッダーにあるか", func(t *testing.T) {
 		m := &Mastodon{opts: &shared.ClientOpts{Server: ts.URL}}
 		res := &r{}
-		u := announcementsEndpoint.URL(m.opts.Server)
+		u := announcementsEndpoint.URL(m.opts.Server, nil)
 		err := m.request("POST", u, nil, true, res)
 		assert.NoError(t, err)
 		assert.Equal(t, "authorization", res.S)
@@ -90,7 +90,7 @@ func TestRequest(t *testing.T) {
 	t.Run("指定したメソッドで送信できているか", func(t *testing.T) {
 		m := &Mastodon{opts: &shared.ClientOpts{Server: ts.URL}}
 		res := &r{}
-		u := announcementsEndpoint.URL(m.opts.Server)
+		u := announcementsEndpoint.URL(m.opts.Server, nil)
 		err := m.request("GET", u, nil, false, res)
 		assert.NoError(t, err)
 		assert.Equal(t, "GET", res.S)

--- a/api/mastodon/endpoints.go
+++ b/api/mastodon/endpoints.go
@@ -3,8 +3,9 @@ package mastodon
 import "github.com/arrow2nd/nekomata/api/shared"
 
 const (
-	oauthAuthorizeEndpoint shared.Endpoint = "oauth/authorize"
-	oauthTokenEndpoint     shared.Endpoint = "oauth/token"
-	announcementsEndpoint  shared.Endpoint = "api/v1/announcements"
-	statusesEndpoint       shared.Endpoint = "api/v1/statuses"
+	oauthAuthorizeEndpoint shared.Endpoint = "/oauth/authorize"
+	oauthTokenEndpoint     shared.Endpoint = "/oauth/token"
+	announcementsEndpoint  shared.Endpoint = "/api/v1/announcements"
+	statusesEndpoint       shared.Endpoint = "/api/v1/statuses"
+	favouriteEndpoint      shared.Endpoint = "/api/v1/statuses/:id/favourite"
 )

--- a/api/mastodon/endpoints.go
+++ b/api/mastodon/endpoints.go
@@ -8,4 +8,5 @@ const (
 	announcementsEndpoint  shared.Endpoint = "/api/v1/announcements"
 	statusesEndpoint       shared.Endpoint = "/api/v1/statuses"
 	favouriteEndpoint      shared.Endpoint = "/api/v1/statuses/:id/favourite"
+	unfavouriteEndpoint    shared.Endpoint = "/api/v1/statuses/:id/unfavourite"
 )

--- a/api/mastodon/toot.go
+++ b/api/mastodon/toot.go
@@ -168,5 +168,19 @@ func (m *Mastodon) DeletePost(id string) (*shared.Post, error) {
 }
 
 func (m *Mastodon) Reaction(id, reaction string) error {
+	p := url.Values{}
+	p.Add(":id", id)
+
+	endpoint := favouriteEndpoint.URL(m.opts.Server, p)
+
+	res := &status{}
+	if err := m.request("POST", endpoint, nil, true, &res); err != nil {
+		return err
+	}
+
+	if !res.Favourited {
+		return fmt.Errorf("failed to favourite (ID: %s)", id)
+	}
+
 	return nil
 }

--- a/api/mastodon/toot.go
+++ b/api/mastodon/toot.go
@@ -184,3 +184,21 @@ func (m *Mastodon) Reaction(id, reaction string) error {
 
 	return nil
 }
+
+func (m *Mastodon) UnReaction(id, reaction string) error {
+	p := url.Values{}
+	p.Add(":id", id)
+
+	endpoint := unfavouriteEndpoint.URL(m.opts.Server, p)
+
+	res := &status{}
+	if err := m.request("POST", endpoint, nil, true, &res); err != nil {
+		return err
+	}
+
+	if res.Favourited {
+		return fmt.Errorf("failed to unfavourite (ID: %s)", id)
+	}
+
+	return nil
+}

--- a/api/mastodon/toot.go
+++ b/api/mastodon/toot.go
@@ -123,11 +123,11 @@ func (m *Mastodon) createPostQuery(opts *shared.CreatePostOpts) url.Values {
 }
 
 func (m *Mastodon) CreatePost(opts *shared.CreatePostOpts) (*shared.Post, error) {
-	url := statusesEndpoint.URL(m.opts.Server, nil)
+	endpoint := statusesEndpoint.URL(m.opts.Server, nil)
 	q := m.createPostQuery(opts)
 
 	res := &status{}
-	if err := m.request("POST", url, q, true, &res); err != nil {
+	if err := m.request("POST", endpoint, q, true, &res); err != nil {
 		return nil, err
 	}
 
@@ -140,13 +140,13 @@ func (m *Mastodon) QuotePost(id string, opts *shared.CreatePostOpts) (*shared.Po
 }
 
 func (m *Mastodon) ReplyPost(replyToId string, opts *shared.CreatePostOpts) (*shared.Post, error) {
-	url := statusesEndpoint.URL(m.opts.Server, nil)
+	endpoint := statusesEndpoint.URL(m.opts.Server, nil)
 
 	q := m.createPostQuery(opts)
 	q.Add("in_reply_to_id", replyToId)
 
 	res := &status{}
-	if err := m.request("POST", url, q, true, &res); err != nil {
+	if err := m.request("POST", endpoint, q, true, &res); err != nil {
 		return nil, err
 	}
 

--- a/api/mastodon/toot.go
+++ b/api/mastodon/toot.go
@@ -123,7 +123,7 @@ func (m *Mastodon) createPostQuery(opts *shared.CreatePostOpts) url.Values {
 }
 
 func (m *Mastodon) CreatePost(opts *shared.CreatePostOpts) (*shared.Post, error) {
-	url := statusesEndpoint.URL(m.opts.Server)
+	url := statusesEndpoint.URL(m.opts.Server, nil)
 	q := m.createPostQuery(opts)
 
 	res := &status{}
@@ -140,7 +140,7 @@ func (m *Mastodon) QuotePost(id string, opts *shared.CreatePostOpts) (*shared.Po
 }
 
 func (m *Mastodon) ReplyPost(replyToId string, opts *shared.CreatePostOpts) (*shared.Post, error) {
-	url := statusesEndpoint.URL(m.opts.Server)
+	url := statusesEndpoint.URL(m.opts.Server, nil)
 
 	q := m.createPostQuery(opts)
 	q.Add("in_reply_to_id", replyToId)
@@ -154,7 +154,7 @@ func (m *Mastodon) ReplyPost(replyToId string, opts *shared.CreatePostOpts) (*sh
 }
 
 func (m *Mastodon) DeletePost(id string) (*shared.Post, error) {
-	u, err := url.JoinPath(statusesEndpoint.URL(m.opts.Server), id)
+	u, err := url.JoinPath(statusesEndpoint.URL(m.opts.Server, nil), id)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create URL for quote: %w", err)
 	}
@@ -165,4 +165,8 @@ func (m *Mastodon) DeletePost(id string) (*shared.Post, error) {
 	}
 
 	return res.ToPost(), nil
+}
+
+func (m *Mastodon) Reaction(id, reaction string) error {
+	return nil
 }

--- a/api/mastodon/toot_test.go
+++ b/api/mastodon/toot_test.go
@@ -27,7 +27,7 @@ const mockStatus = `
   "replies_count": 5,
   "reblogs_count": 6,
   "favourites_count": 10,
-  "favourited": false,
+  "favourited": true,
   "reblogged": false,
   "muted": false,
   "bookmarked": false,
@@ -149,6 +149,23 @@ func TestDeletePost(t *testing.T) {
 
 	m, _ := api.NewClient(os.Stdout, api.ServiceMastodon, &shared.ClientOpts{Server: ts.URL})
 	_, err := m.DeletePost(id)
+
+	assert.NoError(t, err)
+}
+
+func TestReaction(t *testing.T) {
+	id := "012345"
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Contains(t, r.URL.String(), id, "URLに投稿IDが含まれているか")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintln(w, mockStatus)
+	}))
+
+	defer ts.Close()
+
+	m, _ := api.NewClient(os.Stdout, api.ServiceMastodon, &shared.ClientOpts{Server: ts.URL})
+	err := m.Reaction(id, "")
 
 	assert.NoError(t, err)
 }

--- a/api/misskey/authenticate.go
+++ b/api/misskey/authenticate.go
@@ -72,11 +72,11 @@ func (m *Misskey) recieveToken(sessionID string) (*shared.User, error) {
 	p := url.Values{}
 	p.Add(":session_id", sessionID)
 
-	url := miAuthCheckEndpoint.URL(m.opts.Server, p)
-	res, err := http.Post(url, "text/plain", nil)
+	endpoint := miAuthCheckEndpoint.URL(m.opts.Server, p)
+	res, err := http.Post(endpoint, "text/plain", nil)
 	if err != nil {
 		return nil, &shared.RequestError{
-			URL: url,
+			URL: endpoint,
 			Err: err,
 		}
 	}
@@ -91,7 +91,7 @@ func (m *Misskey) recieveToken(sessionID string) (*shared.User, error) {
 	decorder := json.NewDecoder(res.Body)
 	if err := decorder.Decode(authRes); err != nil {
 		return nil, &shared.DecodeError{
-			URL: url,
+			URL: endpoint,
 			Err: err,
 		}
 	}

--- a/api/misskey/authenticate_test.go
+++ b/api/misskey/authenticate_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"testing"
+	"time"
 
 	"github.com/arrow2nd/nekomata/api/shared"
 	"github.com/google/uuid"
@@ -49,6 +50,8 @@ func TestRecieveSessionID(t *testing.T) {
 
 		result := make(chan *result, 1)
 		go run(result, wantSessionID)
+
+		time.Sleep(time.Second)
 
 		res, err := postCallback(wantSessionID)
 		assert.NoError(t, err)

--- a/api/misskey/authenticate_test.go
+++ b/api/misskey/authenticate_test.go
@@ -6,7 +6,6 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"testing"
-	"time"
 
 	"github.com/arrow2nd/nekomata/api/shared"
 	"github.com/google/uuid"
@@ -39,9 +38,10 @@ func TestRecieveSessionID(t *testing.T) {
 	}
 
 	postCallback := func(id string) (*http.Response, error) {
-		q := url.Values{}
-		q.Add("session", id)
-		return http.Post(shared.AuthCallbackURL+"?"+q.Encode(), "", nil)
+		req, _ := http.NewRequest("POST", shared.AuthCallbackURL, nil)
+		req.URL.RawQuery = "session=" + id
+		c := http.DefaultClient
+		return c.Do(req)
 	}
 
 	t.Run("セッションIDが受け取れるか", func(t *testing.T) {
@@ -50,8 +50,6 @@ func TestRecieveSessionID(t *testing.T) {
 
 		result := make(chan *result, 1)
 		go run(result, wantSessionID)
-
-		time.Sleep(time.Second)
 
 		res, err := postCallback(wantSessionID)
 		assert.NoError(t, err)

--- a/api/misskey/authenticate_test.go
+++ b/api/misskey/authenticate_test.go
@@ -20,8 +20,9 @@ func TestCreateAuthorizeURL(t *testing.T) {
 
 	pathParams := url.Values{}
 	pathParams.Add(":session_id", sessionID)
-	wantURL := miAuthEndpoint.URL(m.opts.Server, pathParams)
-	want := wantURL + "?callback=http%3A%2F%2Flocalhost%3A3000%2Fcallback&name=test_app&permission=aaaa%2Cbbbb"
+	endpoint := miAuthEndpoint.URL(m.opts.Server, pathParams)
+
+	want := endpoint + "?callback=http%3A%2F%2Flocalhost%3A3000%2Fcallback&name=test_app&permission=aaaa%2Cbbbb"
 	assert.Equal(t, want, u, "正しい形式で生成されているか")
 }
 

--- a/api/misskey/authenticate_test.go
+++ b/api/misskey/authenticate_test.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
-	"strings"
 	"testing"
 
 	"github.com/arrow2nd/nekomata/api/shared"
@@ -15,12 +14,14 @@ import (
 
 func TestCreateAuthorizeURL(t *testing.T) {
 	m := &Misskey{opts: &shared.ClientOpts{Name: "test_app", Server: "https://example.com"}}
+
 	u, sessionID := m.createAuthorizeURL([]string{"aaaa", "bbbb"})
-
-	want := miAuthEndpoint.URL(m.opts.Server) + "?callback=http%3A%2F%2Flocalhost%3A3000%2Fcallback&name=test_app&permission=aaaa%2Cbbbb"
-	want = strings.Replace(want, ":session_id", sessionID, 1)
-
 	assert.NotEqual(t, "", sessionID, "セッションIDがあるか")
+
+	pathParams := url.Values{}
+	pathParams.Add(":session_id", sessionID)
+	wantURL := miAuthEndpoint.URL(m.opts.Server, pathParams)
+	want := wantURL + "?callback=http%3A%2F%2Flocalhost%3A3000%2Fcallback&name=test_app&permission=aaaa%2Cbbbb"
 	assert.Equal(t, want, u, "正しい形式で生成されているか")
 }
 

--- a/api/misskey/client.go
+++ b/api/misskey/client.go
@@ -27,7 +27,7 @@ func (m *Misskey) post(endpoint shared.Endpoint, in, out interface{}) error {
 		return fmt.Errorf("create payload error (%s): %w", endpoint, err)
 	}
 
-	url := endpoint.URL(m.opts.Server)
+	url := endpoint.URL(m.opts.Server, nil)
 	req, err := http.NewRequest("POST", url, bytes.NewBuffer(payload))
 	if err != nil {
 		return fmt.Errorf("create request error (%s): %w", endpoint, err)

--- a/api/misskey/client.go
+++ b/api/misskey/client.go
@@ -27,8 +27,8 @@ func (m *Misskey) post(endpoint shared.Endpoint, in, out interface{}) error {
 		return fmt.Errorf("create payload error (%s): %w", endpoint, err)
 	}
 
-	url := endpoint.URL(m.opts.Server, nil)
-	req, err := http.NewRequest("POST", url, bytes.NewBuffer(payload))
+	endpointURL := endpoint.URL(m.opts.Server, nil)
+	req, err := http.NewRequest("POST", endpointURL, bytes.NewBuffer(payload))
 	if err != nil {
 		return fmt.Errorf("create request error (%s): %w", endpoint, err)
 	}
@@ -38,7 +38,7 @@ func (m *Misskey) post(endpoint shared.Endpoint, in, out interface{}) error {
 	res, err := client.Do(req)
 	if err != nil {
 		return &shared.RequestError{
-			URL: url,
+			URL: endpointURL,
 			Err: err,
 		}
 	}
@@ -53,7 +53,7 @@ func (m *Misskey) post(endpoint shared.Endpoint, in, out interface{}) error {
 	decorder := json.NewDecoder(res.Body)
 	if err := decorder.Decode(out); err != nil {
 		return &shared.DecodeError{
-			URL: url,
+			URL: endpointURL,
 			Err: err,
 		}
 	}

--- a/api/misskey/endpoints.go
+++ b/api/misskey/endpoints.go
@@ -3,7 +3,7 @@ package misskey
 import "github.com/arrow2nd/nekomata/api/shared"
 
 const (
-	miAuthEndpoint        shared.Endpoint = "miauth/:session_id"
-	miAuthCheckEndpoint   shared.Endpoint = "api/miauth/:session_id/check"
-	announcementsEndpoint shared.Endpoint = "api/announcements"
+	miAuthEndpoint        shared.Endpoint = "/miauth/:session_id"
+	miAuthCheckEndpoint   shared.Endpoint = "/api/miauth/:session_id/check"
+	announcementsEndpoint shared.Endpoint = "/api/announcements"
 )

--- a/api/misskey/note.go
+++ b/api/misskey/note.go
@@ -21,3 +21,7 @@ func (m *Misskey) DeletePost(id string) (*shared.Post, error) {
 func (m *Misskey) Reaction(id, reaction string) error {
 	return nil
 }
+
+func (m *Misskey) UnReaction(id, reaction string) error {
+	return nil
+}

--- a/api/misskey/note.go
+++ b/api/misskey/note.go
@@ -17,3 +17,7 @@ func (m Misskey) ReplyPost(id string, opts *shared.CreatePostOpts) (*shared.Post
 func (m *Misskey) DeletePost(id string) (*shared.Post, error) {
 	return nil, nil
 }
+
+func (m *Misskey) Reaction(id, reaction string) error {
+	return nil
+}

--- a/api/shared/client.go
+++ b/api/shared/client.go
@@ -15,6 +15,8 @@ type Client interface {
 	ReplyPost(string, *CreatePostOpts) (*Post, error)
 	// DeletePost : 投稿を削除
 	DeletePost(string) (*Post, error)
+	// Reaction : 投稿にリアクション
+	Reaction(string, string) error
 }
 
 // ClientOpts : クライアントの設定

--- a/api/shared/client.go
+++ b/api/shared/client.go
@@ -17,6 +17,8 @@ type Client interface {
 	DeletePost(string) (*Post, error)
 	// Reaction : 投稿にリアクション
 	Reaction(string, string) error
+	// UnReaction : 投稿にリアクション
+	UnReaction(string, string) error
 }
 
 // ClientOpts : クライアントの設定

--- a/api/shared/endpoint.go
+++ b/api/shared/endpoint.go
@@ -1,7 +1,21 @@
 package shared
 
+import (
+	"net/url"
+	"strings"
+)
+
 type Endpoint string
 
-func (e Endpoint) URL(host string) string {
-	return host + "/" + string(e)
+func (e Endpoint) URL(host string, pathParams url.Values) string {
+	endpoint := string(e)
+
+	// パスパラメータを設定
+	if pathParams != nil {
+		for k, v := range pathParams {
+			endpoint = strings.Replace(endpoint, k, v[0], 1)
+		}
+	}
+
+	return host + endpoint
 }

--- a/api/shared/endpoint_test.go
+++ b/api/shared/endpoint_test.go
@@ -1,0 +1,52 @@
+package shared_test
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/arrow2nd/nekomata/api/shared"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEnpoint(t *testing.T) {
+	host := "https://example.com"
+
+	tests := []struct {
+		name string
+		e    shared.Endpoint
+		p    url.Values
+		want string
+	}{
+		{
+			name: "単純な結合のみ",
+			e:    "/api/hoge",
+			p:    nil,
+			want: "/api/hoge",
+		},
+		{
+			name: "パスパラメータあり",
+			e:    "/api/hoge/:id",
+			p:    url.Values{":id": []string{"fuga"}},
+			want: "/api/hoge/fuga",
+		},
+		{
+			name: "クエリパラメータあり",
+			e:    "/api/hoge",
+			p:    nil,
+			want: "/api/hoge?a=fuga&b=piyo",
+		},
+		{
+			name: "パスパラメータ + クエリパラメータ",
+			e:    "/api/hoge/:id",
+			p:    url.Values{":id": []string{"fuga"}},
+			want: "/api/hoge/fuga?a=piyo",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.e.URL(host, tc.p)
+			assert.Equal(t, host+tc.want, got)
+		})
+	}
+}

--- a/api/shared/endpoint_test.go
+++ b/api/shared/endpoint_test.go
@@ -29,18 +29,6 @@ func TestEnpoint(t *testing.T) {
 			p:    url.Values{":id": []string{"fuga"}},
 			want: "/api/hoge/fuga",
 		},
-		{
-			name: "クエリパラメータあり",
-			e:    "/api/hoge",
-			p:    nil,
-			want: "/api/hoge?a=fuga&b=piyo",
-		},
-		{
-			name: "パスパラメータ + クエリパラメータ",
-			e:    "/api/hoge/:id",
-			p:    url.Values{":id": []string{"fuga"}},
-			want: "/api/hoge/fuga?a=piyo",
-		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
- feat(api): shared.Endpoint にパスパラメータの置換処理を追加
- feat(api): `Reaction` を追加
- test(api): 不要になったテストを削除
- feat(api/mastodon): ふぁぼを追加
